### PR TITLE
#61 és #62 feladatok - LogContainer fixes

### DIFF
--- a/coffee-cdi/pom.xml
+++ b/coffee-cdi/pom.xml
@@ -60,5 +60,11 @@
 			<artifactId>microprofile-config-api</artifactId>
 		</dependency>
 
+		<!-- Test -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
+++ b/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
@@ -22,6 +22,8 @@ package hu.icellmobilsoft.coffee.cdi.logger;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.MessageFormat;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,14 +54,6 @@ public class LogContainer {
     /**
      * <p>trace.</p>
      */
-    public void trace(String format, Object arg) {
-        String message = format(format, arg);
-        logs.add(new Log(LogLevel.TRACE, message));
-    }
-
-    /**
-     * <p>trace.</p>
-     */
     public void trace(String format, Object... arguments) {
         String message = format(format, arguments);
         logs.add(new Log(LogLevel.TRACE, message));
@@ -70,16 +64,10 @@ public class LogContainer {
      */
     public void trace(String msg, Throwable t) {
         String message = getFullStackTrace(t);
+        logs.add(new Log(LogLevel.TRACE, msg));
         logs.add(new Log(LogLevel.TRACE, message));
     }
 
-    /**
-     * <p>trace.</p>
-     */
-    public void trace(String format, Object arg1, Object arg2) {
-        String message = format(format, arg1, arg2);
-        logs.add(new Log(LogLevel.TRACE, message));
-    }
 
     /**
      * <p>debug.</p>
@@ -88,13 +76,6 @@ public class LogContainer {
         logs.add(new Log(LogLevel.DEBUG, msg));
     }
 
-    /**
-     * <p>debug.</p>
-     */
-    public void debug(String format, Object arg) {
-        String message = format(format, arg);
-        logs.add(new Log(LogLevel.DEBUG, message));
-    }
 
     /**
      * <p>debug.</p>
@@ -109,16 +90,10 @@ public class LogContainer {
      */
     public void debug(String msg, Throwable t) {
         String message = getFullStackTrace(t);
+        logs.add(new Log(LogLevel.DEBUG, msg));
         logs.add(new Log(LogLevel.DEBUG, message));
     }
 
-    /**
-     * <p>debug.</p>
-     */
-    public void debug(String format, Object arg1, Object arg2) {
-        String message = format(format, arg1, arg2);
-        logs.add(new Log(LogLevel.DEBUG, message));
-    }
 
     /**
      * <p>info.</p>
@@ -127,13 +102,6 @@ public class LogContainer {
         logs.add(new Log(LogLevel.INFO, msg));
     }
 
-    /**
-     * <p>info.</p>
-     */
-    public void info(String format, Object arg) {
-        String message = format(format, arg);
-        logs.add(new Log(LogLevel.INFO, message));
-    }
 
     /**
      * <p>info.</p>
@@ -148,16 +116,10 @@ public class LogContainer {
      */
     public void info(String msg, Throwable t) {
         String message = getFullStackTrace(t);
+        logs.add(new Log(LogLevel.INFO, msg));
         logs.add(new Log(LogLevel.INFO, message));
     }
 
-    /**
-     * <p>info.</p>
-     */
-    public void info(String format, Object arg1, Object arg2) {
-        String message = format(format, arg1, arg2);
-        logs.add(new Log(LogLevel.INFO, message));
-    }
 
     /**
      * <p>warn.</p>
@@ -166,13 +128,6 @@ public class LogContainer {
         logs.add(new Log(LogLevel.WARN, msg));
     }
 
-    /**
-     * <p>warn.</p>
-     */
-    public void warn(String format, Object arg) {
-        String message = format(format, arg);
-        logs.add(new Log(LogLevel.WARN, message));
-    }
 
     /**
      * <p>warn.</p>
@@ -187,16 +142,10 @@ public class LogContainer {
      */
     public void warn(String msg, Throwable t) {
         String message = getFullStackTrace(t);
+        logs.add(new Log(LogLevel.WARN, msg));
         logs.add(new Log(LogLevel.WARN, message));
     }
 
-    /**
-     * <p>warn.</p>
-     */
-    public void warn(String format, Object arg1, Object arg2) {
-        String message = format(format, arg1, arg2);
-        logs.add(new Log(LogLevel.WARN, message));
-    }
 
     /**
      * <p>error.</p>
@@ -205,13 +154,6 @@ public class LogContainer {
         logs.add(new Log(LogLevel.ERROR, msg));
     }
 
-    /**
-     * <p>error.</p>
-     */
-    public void error(String format, Object arg) {
-        String message = format(format, arg);
-        logs.add(new Log(LogLevel.ERROR, message));
-    }
 
     /**
      * <p>error.</p>
@@ -226,14 +168,7 @@ public class LogContainer {
      */
     public void error(String msg, Throwable t) {
         String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.ERROR, message));
-    }
-
-    /**
-     * <p>error.</p>
-     */
-    public void error(String format, Object arg1, Object arg2) {
-        String message = format(format, arg1, arg2);
+        logs.add(new Log(LogLevel.ERROR, msg));
         logs.add(new Log(LogLevel.ERROR, message));
     }
 
@@ -279,17 +214,19 @@ public class LogContainer {
     }
 
     private class Log {
+        private OffsetDateTime logDateTime;
         private LogLevel level;
         private String message;
 
         private Log(LogLevel level, String message) {
+            this.logDateTime = OffsetDateTime.now();
             this.level = level;
             this.message = message;
         }
 
         @Override
         public String toString() {
-            return level + ":" + message;
+            return MessageFormat.format("[{}]{}:{}",DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(logDateTime),level,message);
         }
     }
 

--- a/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
+++ b/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
@@ -226,7 +226,7 @@ public class LogContainer {
 
         @Override
         public String toString() {
-            return MessageFormat.format("[{}]{}:{}",DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(logDateTime),level,message);
+            return MessageFormat.format("[{0}]{1}:{2}",DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(logDateTime),level,message);
         }
     }
 

--- a/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
+++ b/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
@@ -22,7 +22,7 @@ package hu.icellmobilsoft.coffee.cdi.logger;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.MessageFormat;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -63,8 +63,7 @@ public class LogContainer {
      * <p>trace.</p>
      */
     public void trace(String msg, Throwable t) {
-        String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.TRACE, msg));
+        String message = getFullStackTrace(msg, t);
         logs.add(new Log(LogLevel.TRACE, message));
     }
 
@@ -89,8 +88,7 @@ public class LogContainer {
      * <p>debug.</p>
      */
     public void debug(String msg, Throwable t) {
-        String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.DEBUG, msg));
+        String message = getFullStackTrace(msg, t);
         logs.add(new Log(LogLevel.DEBUG, message));
     }
 
@@ -115,8 +113,7 @@ public class LogContainer {
      * <p>info.</p>
      */
     public void info(String msg, Throwable t) {
-        String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.INFO, msg));
+        String message = getFullStackTrace(msg, t);
         logs.add(new Log(LogLevel.INFO, message));
     }
 
@@ -141,8 +138,7 @@ public class LogContainer {
      * <p>warn.</p>
      */
     public void warn(String msg, Throwable t) {
-        String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.WARN, msg));
+        String message = getFullStackTrace(msg, t);
         logs.add(new Log(LogLevel.WARN, message));
     }
 
@@ -167,8 +163,7 @@ public class LogContainer {
      * <p>error.</p>
      */
     public void error(String msg, Throwable t) {
-        String message = getFullStackTrace(t);
-        logs.add(new Log(LogLevel.ERROR, msg));
+        String message = getFullStackTrace(msg, t);
         logs.add(new Log(LogLevel.ERROR, message));
     }
 
@@ -214,19 +209,19 @@ public class LogContainer {
     }
 
     private class Log {
-        private OffsetDateTime logDateTime;
+        private LocalDateTime logDateTime;
         private LogLevel level;
         private String message;
 
         private Log(LogLevel level, String message) {
-            this.logDateTime = OffsetDateTime.now();
+            this.logDateTime = LocalDateTime.now();
             this.level = level;
             this.message = message;
         }
 
         @Override
         public String toString() {
-            return MessageFormat.format("[{0}]{1}:{2}",DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(logDateTime),level,message);
+            return MessageFormat.format("[{0}]{1}:{2}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(logDateTime), level, message);
         }
     }
 
@@ -241,6 +236,16 @@ public class LogContainer {
             }
         }
         return highestLogLevel;
+    }
+
+    private static String getFullStackTrace(String msg, Throwable t) {
+        StringWriter sw = new StringWriter();
+        sw.append(msg);
+        sw.append(" > stacktrace: \n");
+        sw.append("[");
+        sw.append(getFullStackTrace(t));
+        sw.append("]");
+        return sw.toString();
     }
 
     /**

--- a/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
+++ b/coffee-cdi/src/main/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainer.java
@@ -221,7 +221,7 @@ public class LogContainer {
 
         @Override
         public String toString() {
-            return MessageFormat.format("[{0}]{1}:{2}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(logDateTime), level, message);
+            return MessageFormat.format("[{0}] {1}: {2}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(logDateTime), level, message);
         }
     }
 

--- a/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
+++ b/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
@@ -1,0 +1,105 @@
+package hu.icellmobilsoft.coffee.cdi.logger;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * LogContainer logging tests
+ * 
+ * @author peter.szabo
+ */
+@DisplayName("LogContainer logging tests")
+public class LogContainerLogTests {
+
+    @Test
+    @DisplayName("Test Trace level logs")
+    public void testTraceLogs() {
+        LogContainer logContainer = new LogContainer();
+        String logLevel = "Trace";
+        try {
+            logContainer.trace(logLevel + " message");
+            logContainer.trace(logLevel + " message with param:{0}", "param1");
+            throw new Exception("Test exception");
+        } catch (Exception e) {
+            logContainer.trace(logLevel + " Exception log.", e);
+        }
+        testLog(logContainer, logLevel);
+    }
+
+    @Test
+    @DisplayName("Test Debug level logs")
+    public void testDebugLogs() {
+        LogContainer logContainer = new LogContainer();
+        String logLevel = "Debug";
+        try {
+            logContainer.debug(logLevel + " message");
+            logContainer.debug(logLevel + " message with param:{0}", "param1");
+            throw new Exception("Test exception");
+        } catch (Exception e) {
+            logContainer.debug(logLevel + " Exception log.", e);
+        }
+        testLog(logContainer, logLevel);
+    }
+
+    @Test
+    @DisplayName("Test Info level logs")
+    public void testInfoLogs() {
+        LogContainer logContainer = new LogContainer();
+        String logLevel = "Info";
+        try {
+            logContainer.info(logLevel + " message");
+            logContainer.info(logLevel + " message with param:{0}", "param1");
+            throw new Exception("Test exception");
+        } catch (Exception e) {
+            logContainer.info(logLevel + " Exception log.", e);
+        }
+        testLog(logContainer, logLevel);
+    }
+
+    @Test
+    @DisplayName("Test Warn level logs")
+    public void testWarnLogs() {
+        LogContainer logContainer = new LogContainer();
+        String logLevel = "Warn";
+        try {
+            logContainer.warn(logLevel + " message");
+            logContainer.warn(logLevel + " message with param:{0}", "param1");
+            throw new Exception("Test exception");
+        } catch (Exception e) {
+            logContainer.warn(logLevel + " Exception log.", e);
+        }
+        testLog(logContainer, logLevel);
+    }
+
+    @Test
+    @DisplayName("Test Error level logs")
+    public void testErrorLogs() {
+        LogContainer logContainer = new LogContainer();
+        String logLevel = "Error";
+        try {
+            logContainer.error(logLevel + " message");
+            logContainer.error(logLevel + " message with param:{0}", "param1");
+            throw new Exception("Test exception");
+        } catch (Exception e) {
+            logContainer.error(logLevel + " Exception log.", e);
+        }
+        testLog(logContainer, logLevel);
+    }
+
+    private void testLog(LogContainer logContainer, String logLevel) {
+        String[] logContainerRows = logContainer.toString().split("\\n");
+        Assertions.assertTrue(
+                Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel + " message",
+                        logContainerRows[0]));
+        Assertions.assertTrue(Pattern.matches(
+                "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel + " message with param:param1",
+                logContainerRows[1]));
+
+        Assertions.assertTrue(Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel
+                + " Exception log. > stacktrace: ", logContainerRows[2]));
+        Assertions.assertTrue(logContainerRows[3].startsWith("[java.lang.Exception: Test exception"));
+    }
+}

--- a/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
+++ b/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
@@ -92,13 +92,13 @@ public class LogContainerLogTests {
     private void testLog(LogContainer logContainer, String logLevel) {
         String[] logContainerRows = logContainer.toString().split("\\n");
         Assertions.assertTrue(
-                Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel + " message",
+                Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\] " + logLevel.toUpperCase() + ": " + logLevel + " message",
                         logContainerRows[0]));
         Assertions.assertTrue(Pattern.matches(
-                "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel + " message with param:param1",
+                "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\] " + logLevel.toUpperCase() + ": " + logLevel + " message with param:param1",
                 logContainerRows[1]));
 
-        Assertions.assertTrue(Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\]" + logLevel.toUpperCase() + ":" + logLevel
+        Assertions.assertTrue(Pattern.matches("\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{0,9}\\] " + logLevel.toUpperCase() + ": " + logLevel
                 + " Exception log. > stacktrace: ", logContainerRows[2]));
         Assertions.assertTrue(logContainerRows[3].startsWith("[java.lang.Exception: Test exception"));
     }

--- a/docs/migration/migration110to120.adoc
+++ b/docs/migration/migration110to120.adoc
@@ -3,12 +3,22 @@
 coff:ee v1.1.0 -> v1.2.0 migrációs leírás, újdonságok, változások leírása
 
 == Változások
-=== coffee-rest
 
-* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml,text/xml vagy application/atom+xml.
-A json kiírás is mediaType függővé lett téve.
-Egyéb esetben az objektum toString() metódusával kerül kiírásra a válasz objektum.
+=== coffee-cdi
+* LogContainer-ben a különböző logszintek megadásánál, a formázott üzenetekhez használt több argumentum megadási lehetőségek közül, csak a Varargs maradt meg (multiple arguments).
+* LogContainer logjai autómatikusan kapnak létrejöttükkor egy LocalDateTime.now() -t, ami a loggok kiírásakor is kiíródik.
+* LogContainer-ben Throwable kiírásakor mostmár a paraméterben kapott üzenet is kiíródik, valamint struktúráltabban íródik ki hozzá a stacktrace.
 
 ==== Átállás
 
-Nem szükséges semmi plusz teendő, visszafelé kompatibilis a változtatás.
+A változtatások nem eredményeznek átállási munkálatokat, visszafelé kompatibilis.
+
+=== coffee-rest
+
+* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml,text/xml vagy application/atom+xml.
+* RequestResponseLogger válasz kiíráatásnál, a json kiírás is mediaType függővé lett téve.
+* RequestResponseLogger válasz kiíráatásnál minden egyéb, nem String objektum esetben, az objektum toString() metódusával kerül kiírásra a válasz objektum.
+
+==== Átállás
+
+A változtatások nem eredményeznek átállási munkálatokat, visszafelé kompatibilis.


### PR DESCRIPTION
#61 - (String msg, Throwable t) paraméter loggoknál az msg is bekerül a logok közé fix

#62 - azon loggolások ahol a metódusban meg van kötve az argumentum száma, törlésre kerülnek mert van olyan amiben dinamikusan lehet átadni, így ezek feleslegesek lettek.

Dátum loggolás is került a Log osztályba.