### PR TITLE
#59 - RequestResponseLogger.printEntity metódus felkészítése XML logg…

### DIFF
--- a/coffee-module/coffee-module-mp/coffee-module-mp-restclient/src/main/java/hu/icellmobilsoft/coffee/module/mp/restclient/provider/DefaultLoggerClientRequestFilter.java
+++ b/coffee-module/coffee-module-mp/coffee-module-mp-restclient/src/main/java/hu/icellmobilsoft/coffee/module/mp/restclient/provider/DefaultLoggerClientRequestFilter.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
 
 import hu.icellmobilsoft.coffee.cdi.logger.AppLogger;
 import hu.icellmobilsoft.coffee.cdi.logger.LogProducer;
@@ -117,17 +118,18 @@ public class DefaultLoggerClientRequestFilter implements ClientRequestFilter {
     protected String logEntity(ClientRequestContext requestContext) throws IOException {
         StringBuilder msg = new StringBuilder();
         Object entity = requestContext.getEntity();
+        MediaType mediaType = requestContext.getMediaType();
         if (entity != null) {
             msg.append(
                     requestResponseLogger.printEntity(entity, RestLoggerUtil.getMaxEntityLogSize(requestContext, LogSpecifierTarget.CLIENT_REQUEST),
-                            RequestResponseLogger.REQUEST_PREFIX, true));
+                            RequestResponseLogger.REQUEST_PREFIX, true, mediaType));
         } else {
             OutputStreamCopier osc = new OutputStreamCopier(requestContext.getEntityStream());
             requestContext.setEntityStream(osc);
             String requestText = new String(osc.getCopy(), StandardCharsets.UTF_8);
             msg.append(requestResponseLogger.printEntity(requestText,
-                    RestLoggerUtil.getMaxEntityLogSize(requestContext, LogSpecifierTarget.CLIENT_REQUEST), RequestResponseLogger.REQUEST_PREFIX,
-                    true));
+                    RestLoggerUtil.getMaxEntityLogSize(requestContext, LogSpecifierTarget.CLIENT_REQUEST), RequestResponseLogger.REQUEST_PREFIX, true,
+                    mediaType));
         }
         return msg.toString();
     }

--- a/coffee-rest/src/main/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLogger.java
+++ b/coffee-rest/src/main/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLogger.java
@@ -396,9 +396,10 @@ public class RequestResponseLogger {
         String entityText = null;
         if (entity instanceof String) {
             entityText = (String) entity;
-        } else if (mediaType != null && StringUtils.containsIgnoreCase(mediaType.getSubtype(), "json")) {
+        } else if (mediaType != null && MediaType.APPLICATION_JSON_TYPE.getSubtype().equals(mediaType.getSubtype())) {
             entityText = JsonUtil.toJson(entity);
-        } else if (mediaType != null && StringUtils.containsIgnoreCase(mediaType.getSubtype(), "xml")) {
+        } else if (mediaType != null && (MediaType.APPLICATION_XML_TYPE.getSubtype().equals(mediaType.getSubtype()) //
+                || MediaType.APPLICATION_ATOM_XML_TYPE.getSubtype().equals(mediaType.getSubtype()))) {
             entityText = MarshallingUtil.marshall(entity);
         } else {
             entityText = entity.toString();

--- a/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
+++ b/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
@@ -1,0 +1,57 @@
+package hu.icellmobilsoft.coffee.rest.log;
+
+import java.time.OffsetDateTime;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hu.icellmobilsoft.coffee.dto.common.commonservice.BaseResponse;
+import hu.icellmobilsoft.coffee.dto.common.commonservice.ContextType;
+import hu.icellmobilsoft.coffee.dto.common.commonservice.FunctionCodeType;
+
+/**
+ * RequestResponseLogger class tests
+ * 
+ * @author peter.szabo
+ */
+@DisplayName("RequestResponseLogger class tests")
+public class RequestResponseLoggerTest {
+
+    private RequestResponseLogger requestResponseLogger = new RequestResponseLogger();
+
+    @Test
+    @DisplayName("Test printEntity with Json object and application/json media type")
+    public void printJsonEntityTest() {
+        BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
+                .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, MediaType.APPLICATION_JSON_TYPE);
+        Assertions.assertTrue(responseText.startsWith("entity: [{\"context\":{\"requestId\":\"TEST\",\"timestamp\""));
+
+    }
+
+    @Test
+    @DisplayName("Test printEntity with String object and without media type")
+    public void printStringEntityTest() {
+        String responseText = requestResponseLogger.printEntity("<div>Hello World</div>", null, "", false, null);
+        Assertions.assertTrue(responseText.startsWith("entity: [<div>Hello World</div>]"));
+    }
+
+    @Test
+    @DisplayName("Test printEntity with Object object and without media type")
+    public void printObjectEntityTest() {
+        String responseText = requestResponseLogger.printEntity(new Object(), null, "", false, null);
+        Assertions.assertTrue(responseText.startsWith("entity: [java.lang.Object@"));
+    }
+
+    @Test
+    @DisplayName("Test printEntity with XML object and application/xml media type")
+    public void printXmlEntityTest() {
+        BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
+                .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, MediaType.APPLICATION_XML_TYPE);
+        Assertions.assertTrue(responseText.startsWith("entity: [<?xml"));
+    }
+}

--- a/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
+++ b/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
@@ -1,5 +1,6 @@
 package hu.icellmobilsoft.coffee.rest.log;
 
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 
 import javax.ws.rs.core.MediaType;
@@ -23,11 +24,12 @@ public class RequestResponseLoggerTest {
     private RequestResponseLogger requestResponseLogger = new RequestResponseLogger();
 
     @Test
-    @DisplayName("Test printEntity with Json object and application/json media type")
+    @DisplayName("Test printEntity with Json object and application/json;charset=UTF-8 media type")
     public void printJsonEntityTest() {
         BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
                 .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
-        String responseText = requestResponseLogger.printEntity(response, null, "", false, MediaType.APPLICATION_JSON_TYPE);
+        MediaType mediaType = new MediaType("application","json",StandardCharsets.UTF_8.displayName());
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, mediaType);
         Assertions.assertTrue(responseText.startsWith("entity: [{\"context\":{\"requestId\":\"TEST\",\"timestamp\""));
 
     }
@@ -51,7 +53,28 @@ public class RequestResponseLoggerTest {
     public void printXmlEntityTest() {
         BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
                 .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
-        String responseText = requestResponseLogger.printEntity(response, null, "", false, MediaType.APPLICATION_XML_TYPE);
+        MediaType mediaType = new MediaType("application","xml",StandardCharsets.UTF_8.displayName());
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, mediaType);
+        Assertions.assertTrue(responseText.startsWith("entity: [<?xml"));
+    }
+
+    @Test
+    @DisplayName("Test printEntity with XML object and application/atom+xml media type")
+    public void printAtomPlusXmlMediaTypeEntityTest() {
+        BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
+                .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
+        MediaType mediaType = MediaType.APPLICATION_ATOM_XML_TYPE;
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, mediaType);
+        Assertions.assertTrue(responseText.startsWith("entity: [<?xml"));
+    }
+
+    @Test
+    @DisplayName("Test printEntity with XML object and text/xml media type")
+    public void printTextXmlMediaTypeEntityTest() {
+        BaseResponse response = new BaseResponse().withMessage("msg").withFuncCode(FunctionCodeType.OK)
+                .withContext(new ContextType().withRequestId("TEST").withTimestamp(OffsetDateTime.now()));
+        MediaType mediaType = MediaType.TEXT_XML_TYPE;
+        String responseText = requestResponseLogger.printEntity(response, null, "", false, mediaType);
         Assertions.assertTrue(responseText.startsWith("entity: [<?xml"));
     }
 }

--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -2,3 +2,4 @@
 = Migrációs leírások
 
 include::migration/migration100to110.adoc[leveloffset=+1]
+include::migration/migration110to120.adoc[leveloffset=+1]

--- a/docs/migration/migration110to120.adoc
+++ b/docs/migration/migration110to120.adoc
@@ -5,7 +5,9 @@ coff:ee v1.1.0 -> v1.2.0 migrációs leírás, újdonságok, változások leír�
 == Változások
 === coffee-rest
 
-* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml. A json kiírás is mediaType függővé lett téve. Egyéb esetben az objektum toString() metódusával kerül kiírásra a válasz objektum.
+* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml vagy application/atom+xml.
+A json kiírás is mediaType függővé lett téve.
+Egyéb esetben az objektum toString() metódusával kerül kiírásra a válasz objektum.
 
 ==== Átállás
 

--- a/docs/migration/migration110to120.adoc
+++ b/docs/migration/migration110to120.adoc
@@ -5,7 +5,7 @@ coff:ee v1.1.0 -> v1.2.0 migrációs leírás, újdonságok, változások leír�
 == Változások
 === coffee-rest
 
-* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml vagy application/atom+xml.
+* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml,text/xml vagy application/atom+xml.
 A json kiírás is mediaType függővé lett téve.
 Egyéb esetben az objektum toString() metódusával kerül kiírásra a válasz objektum.
 

--- a/docs/migration/migration110to120.adoc
+++ b/docs/migration/migration110to120.adoc
@@ -1,0 +1,12 @@
+= v1.1.0 → v1.2.0
+
+coff:ee v1.1.0 -> v1.2.0 migrációs leírás, újdonságok, változások leírása
+
+== Változások
+=== coffee-rest
+
+* RequestResponseLogger válasz kiíráatás kibővült xml kiírással, ha a mediaType application/xml. A json kiírás is mediaType függővé lett téve. Egyéb esetben az objektum toString() metódusával kerül kiírásra a válasz objektum.
+
+==== Átállás
+
+Nem szükséges semmi plusz teendő, visszafelé kompatibilis a változtatás.


### PR DESCRIPTION
RequestResponseLogger.printEntity metódus felkészítése XML loggolásra, valamint általánosan a toString használatára hogy mindent ki lehessen loggolni. (ReflectionToStringBuilderen gondolkoztam, de sok benne a buktató)