### PR TITLE
#74 - DefaultEtcdConfigImpl modification

### DIFF
--- a/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
+++ b/coffee-cdi/src/test/java/hu/icellmobilsoft/coffee/cdi/logger/LogContainerLogTests.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Coffee
+ * %%
+ * Copyright (C) 2020 i-Cell Mobilsoft Zrt.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package hu.icellmobilsoft.coffee.cdi.logger;
 
 import java.util.regex.Pattern;

--- a/coffee-module/coffee-module-etcd/src/main/java/hu/icellmobilsoft/coffee/module/etcd/config/DefaultEtcdConfigImpl.java
+++ b/coffee-module/coffee-module-etcd/src/main/java/hu/icellmobilsoft/coffee/module/etcd/config/DefaultEtcdConfigImpl.java
@@ -20,11 +20,10 @@
 package hu.icellmobilsoft.coffee.module.etcd.config;
 
 import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import javax.inject.Provider;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import hu.icellmobilsoft.coffee.tool.utils.config.ConfigUtil;
 
 /**
  * ETCD configuration values from microprofile-config
@@ -35,15 +34,13 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Dependent
 public class DefaultEtcdConfigImpl implements EtcdConfig {
 
-    @SuppressWarnings("cdi-ambiguous-dependency")
-    @Inject
-    @ConfigProperty(name = "etcd.default.url", defaultValue = "http://localhost:2379")
-    private Provider<String> url;
+    private String urlKey = "etcd.default.url";
 
     /** {@inheritDoc} */
     @Override
     public String[] getUrl() {
-        String urlString = url.get();
+        String urlString = ConfigUtil.defaultConfig().getOptionalValue(urlKey, String.class).orElse("http://localhost:2379");
         return StringUtils.split(urlString, ",");
     }
+
 }

--- a/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
+++ b/coffee-rest/src/test/java/hu/icellmobilsoft/coffee/rest/log/RequestResponseLoggerTest.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Coffee
+ * %%
+ * Copyright (C) 2020 i-Cell Mobilsoft Zrt.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package hu.icellmobilsoft.coffee.rest.log;
 
 import java.nio.charset.StandardCharsets;

--- a/coffee-tool/src/main/java/hu/icellmobilsoft/coffee/tool/utils/config/ConfigUtil.java
+++ b/coffee-tool/src/main/java/hu/icellmobilsoft/coffee/tool/utils/config/ConfigUtil.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * Coffee
+ * %%
+ * Copyright (C) 2020 i-Cell Mobilsoft Zrt.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package hu.icellmobilsoft.coffee.tool.utils.config;
+
+import javax.enterprise.inject.Vetoed;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+/**
+ * ConfigUtil
+ * 
+ * @author czenczl
+ * @since 1.2.0
+ */
+@Vetoed
+public class ConfigUtil {
+
+    /**
+     * Get the default configuration sources
+     * 
+     * @return the config
+     */
+    public static Config defaultConfig() {
+        // Default config sources (sys, env, mp-c.properties)
+        return ConfigProviderResolver.instance().getBuilder().addDefaultSources().build();
+    }
+}


### PR DESCRIPTION
DefaultEtcdConfigImpl megpróbálja az etcd szerverről feloldani azt hogy hova kell csatlakozni az etcdhez, ez stack overflow-t okoz, ha microprofile configban található a kulcs. Csak a default config forrásokból szabad kulcsot feloldani.

config priority:
...
etcdConfig - 150
microprofile - 100
...