### PR TITLE
#183 RedisServiceProducer memory leak fix

### DIFF
--- a/coffee-jpa/src/main/java/hu/icellmobilsoft/coffee/jpa/sql/entity/EntityHelper.java
+++ b/coffee-jpa/src/main/java/hu/icellmobilsoft/coffee/jpa/sql/entity/EntityHelper.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Vetoed;
 import javax.enterprise.inject.spi.CDI;
 import javax.persistence.EntityManager;
@@ -84,8 +85,13 @@ public class EntityHelper {
         if (entity == null) {
             return null;
         }
-        EntityManager em = CDI.current().select(EntityManager.class).get();
-        return (String) em.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(entity);
+        Instance<EntityManager> instance = CDI.current().select(EntityManager.class);
+        EntityManager em = instance.get();
+        try {
+            return (String) em.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(entity);
+        } finally {
+            instance.destroy(em);
+        }
     }
 
     /**

--- a/coffee-module/coffee-module-etcd/src/main/java/hu/icellmobilsoft/coffee/module/etcd/producer/DefaultEtcdFactory.java
+++ b/coffee-module/coffee-module-etcd/src/main/java/hu/icellmobilsoft/coffee/module/etcd/producer/DefaultEtcdFactory.java
@@ -108,6 +108,18 @@ public class DefaultEtcdFactory {
     }
 
     /**
+     * Disposes the managed EtcdService
+     *
+     * @param etcdService
+     *            object to dispose
+     */
+    public void disposeEtcdService(@Disposes EtcdService etcdService) {
+        if (etcdService != null) {
+            CDI.current().destroy(etcdService.getEtcdRepository());
+        }
+    }
+
+    /**
      * Producer for default ConfigEtcdService
      * 
      * @return ConfigEtcdService
@@ -119,5 +131,17 @@ public class DefaultEtcdFactory {
         EtcdService etcdService = CDI.current().select(EtcdService.class).get();
         configEtcdService.init(etcdService);
         return configEtcdService;
+    }
+
+    /**
+     * Disposes the managed ConfigEtcdService
+     *
+     * @param configEtcdService
+     *            object to dispose
+     */
+    public void disposeConfigEtcdService(@Disposes ConfigEtcdService configEtcdService) {
+        if (configEtcdService != null) {
+            CDI.current().destroy(configEtcdService.getEtcdService());
+        }
     }
 }

--- a/coffee-module/coffee-module-mongodb/src/main/java/hu/icellmobilsoft/coffee/module/mongodb/extension/MongoDbClientFactory.java
+++ b/coffee-module/coffee-module-mongodb/src/main/java/hu/icellmobilsoft/coffee/module/mongodb/extension/MongoDbClientFactory.java
@@ -84,7 +84,9 @@ public class MongoDbClientFactory {
         String configKey = annotation.map(MongoClientConfiguration::configKey).orElse(null);
 
         // create config helper
-        MongoConfigHelper mongoConfigHelper = CDI.current().select(MongoConfigHelper.class).get();
+        Instance<MongoConfigHelper> configHelperInstance = CDI.current().select(MongoConfigHelper.class);
+        MongoConfigHelper mongoConfigHelper = configHelperInstance.get();
+        configHelperInstance.destroy(mongoConfigHelper);
         mongoConfigHelper.setConfigKey(configKey);
 
         // check if client already exist, synchronized will prevent connection leak

--- a/coffee-module/coffee-module-mongodb/src/main/java/hu/icellmobilsoft/coffee/module/mongodb/handler/MongoDbHandler.java
+++ b/coffee-module/coffee-module-mongodb/src/main/java/hu/icellmobilsoft/coffee/module/mongodb/handler/MongoDbHandler.java
@@ -19,6 +19,7 @@
  */
 package hu.icellmobilsoft.coffee.module.mongodb.handler;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
@@ -80,6 +81,16 @@ public class MongoDbHandler {
             throw new TechnicalException(CoffeeFaultType.WRONG_OR_MISSING_PARAMETERS, "mongoDbConfig is not set!");
         }
         return mongoFactory.getMongoClient(mongoDbConfig.getUri());
+    }
+
+    /**
+     * Disposes the managed {@link #mongoService} field
+     */
+    @PreDestroy
+    public void dispose() {
+        if (mongoService != null) {
+            CDI.current().destroy(mongoService);
+        }
     }
 
     /**

--- a/coffee-module/coffee-module-redis/src/main/java/hu/icellmobilsoft/coffee/module/redis/interceptor/RedisCachingInterceptor.java
+++ b/coffee-module/coffee-module-redis/src/main/java/hu/icellmobilsoft/coffee/module/redis/interceptor/RedisCachingInterceptor.java
@@ -130,6 +130,10 @@ public class RedisCachingInterceptor {
         } catch (Exception e) {
             log.error("Exception on Redis [{0}]", e.getMessage(), e);
             objectToReturn = ctx.proceed();
+        } finally {
+            if (redisService != null) {
+                CDI.current().destroy(redisService);
+            }
         }
         return objectToReturn;
     }

--- a/coffee-module/coffee-module-redisstream/src/main/java/hu/icellmobilsoft/coffee/module/redisstream/consumer/RedisStreamConsumerExecutor.java
+++ b/coffee-module/coffee-module-redisstream/src/main/java/hu/icellmobilsoft/coffee/module/redisstream/consumer/RedisStreamConsumerExecutor.java
@@ -103,11 +103,12 @@ public class RedisStreamConsumerExecutor implements IRedisStreamConsumerExecutor
     public void startLoop() {
         consumerIdentifier = RandomUtil.generateId();
         endLoop = false;
+        CDI<Object> cdi = CDI.current();
         // óvatos futás, ellenőrzi a stream es csoport létezését
         boolean prudentRun = true;
         while (!endLoop) {
             Optional<StreamEntry> streamEntry = Optional.empty();
-            Instance<Jedis> jedisInstance = CDI.current().select(Jedis.class, new RedisConnection.Literal(redisConfigKey));
+            Instance<Jedis> jedisInstance = cdi.select(Jedis.class, new RedisConnection.Literal(redisConfigKey));
             Jedis jedis = null;
             try {
                 jedis = jedisInstance.get();
@@ -150,6 +151,7 @@ public class RedisStreamConsumerExecutor implements IRedisStreamConsumerExecutor
                     // el kell engedni a connectiont
                     jedisInstance.destroy(jedis);
                 }
+                cdi.destroy(this);
                 MDC.clear();
             }
         }

--- a/coffee-module/coffee-module-ruleng/src/main/java/hu/icellmobilsoft/coffee/module/ruleng/evaluator/AbstractEvaluator.java
+++ b/coffee-module/coffee-module-ruleng/src/main/java/hu/icellmobilsoft/coffee/module/ruleng/evaluator/AbstractEvaluator.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.util.TypeLiteral;
@@ -254,6 +255,22 @@ public abstract class AbstractEvaluator<INPUT, RULERESULT extends RuleResult> im
             validationResults.addAll(ruleResults);
         }
         return validationResults;
+    }
+
+    /**
+     * Destroys rule CDI instances
+     */
+    @PreDestroy
+    public void dispose() {
+        if (groupedRules == null) {
+            return;
+        }
+        CDI<Object> cdi = CDI.current();
+        for (List<IRule<INPUT, RULERESULT>> rules : groupedRules.values()) {
+            for (IRule<INPUT, RULERESULT> rule : rules) {
+                cdi.destroy(rule);
+            }
+        }
     }
 
     /**

--- a/docs/migration/migration150to160.adoc
+++ b/docs/migration/migration150to160.adoc
@@ -7,6 +7,7 @@ coff:ee v1.5.0 -> v1.6.0 migrációs leírás, újdonságok, változások leír�
 * Bump Jedis 3.3.0 -> 3.6.0 - Natív java 8 és Redis 6.2 support
 * Bump apache httpcore 4.4.5 -> 4.4.13 - https://archive.apache.org/dist/httpcomponents/httpcore/RELEASE_NOTES-4.4.x.txt
 * Bump apache httpclient 4.5.4 -> 4.5.13 - https://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt
+* `CDI#select`-tel létrehozott dependent scope-ú objektumok felszabadítása
 
 === coffee-module-redis
 Redis 6.2 upgrade változást hozott hogy a timeout megadása int-ről long-ra változott.


### PR DESCRIPTION
closes #183

Ha `CDI.current().select(...).get()`-et hívunk, úgy, hogy dependent scope-ú objektumot ad vissza, a frissen legyártott objektumot az Instance tárolja (és nem engedi a GC-nek az összeszedését), addig amíg destroy-t nem hívunk a `.get()`-tel visszakapott objektumra. 