### PR TITLE
Coffee 320 - RandomUtil.generateId 17 karakteres stringet ad vissza

### DIFF
--- a/coffee-tool/src/main/java/hu/icellmobilsoft/coffee/tool/utils/string/RandomUtil.java
+++ b/coffee-tool/src/main/java/hu/icellmobilsoft/coffee/tool/utils/string/RandomUtil.java
@@ -130,14 +130,14 @@ public class RandomUtil {
     }
 
     /**
-     * Generates sequential index. Restarts sequence at value 1296.
+     * Generates sequential index. Restarts sequence when value greater than 1295.
      * 
      * @return next index
      */
     protected static synchronized int getNextIndex() {
         generatedIndex++;
         // MAX a ZZ
-        if (generatedIndex > 1296) {
+        if (generatedIndex > 1295) {
             generatedIndex = 0;
         }
         return generatedIndex;

--- a/coffee-tool/src/test/java/hu/icellmobilsoft/coffee/tool/utils/string/RandomUtilTest.java
+++ b/coffee-tool/src/test/java/hu/icellmobilsoft/coffee/tool/utils/string/RandomUtilTest.java
@@ -41,11 +41,13 @@ class RandomUtilTest {
         // given
 
         // when
-        String actual = RandomUtil.generateId();
+        for (int i = 0; i < 1297; i++) {
+            String actual = RandomUtil.generateId();
 
-        // then
-        Assertions.assertNotNull(actual);
-        Assertions.assertTrue(actual.matches(ID_REGEX));
+            // then
+            Assertions.assertNotNull(actual);
+            Assertions.assertTrue(actual.matches(ID_REGEX));
+        }
     }
 
     @DisplayName("Testing paddl()")

--- a/docs/migration/migration1110to1120.adoc
+++ b/docs/migration/migration1110to1120.adoc
@@ -11,3 +11,7 @@ Bevezetésre került a link:#TransactionHelper[TransactionHelper] osztály.
 === coffee-tool
 
 RandomUtil osztályban a generateId a javadoc-ban írt 16 karakter helyett 17-et is tudott visszaadni, mert a getNextIndex metódusban tovább tudott futni az index 1296-ig is, amit a generateId-ban 36-os számrendszerben 100-ra alakított, így túllépett. Javítás 1295-ig engedi az indexet.
+
+==== Átállás
+
+A változtatások nem eredményeznek átállási munkálatokat, visszafelé kompatibilis.

--- a/docs/migration/migration1110to1120.adoc
+++ b/docs/migration/migration1110to1120.adoc
@@ -7,3 +7,7 @@ coff:ee v1.11.0 -> v1.12.0 migrációs leírás, újdonságok, változások leí
 === coffee-jpa
 
 Bevezetésre került a link:#TransactionHelper[TransactionHelper] osztály.
+
+=== coffee-tool
+
+RandomUtil osztályban a generateId a javadoc-ban írt 16 karakter helyett 17-et is tudott visszaadni, mert a getNextIndex metódusban tovább tudott futni az index 1296-ig is, amit a generateId-ban 36-os számrendszerben 100-ra alakított, így túllépett. Javítás 1295-ig engedi az indexet.


### PR DESCRIPTION
RandomUtil.getNextIndex metódus tud 1296-ot is visszaadni ami a RandomUtil.generateId -ban 17 karakteres szöveget eredményez, mert az 1296 36os számrendszerben 100 lesz.