### PR TITLE
#342 batchservice blob mentés hiba

### DIFF
--- a/coffee-jpa/src/main/java/hu/icellmobilsoft/coffee/jpa/sql/batch/BatchService.java
+++ b/coffee-jpa/src/main/java/hu/icellmobilsoft/coffee/jpa/sql/batch/BatchService.java
@@ -635,7 +635,7 @@ public class BatchService {
             setBooleanPsObject(ps, parameterIndex, value);
             break;
         default:
-            ps.setObject(parameterIndex, value, singleColumn.sqlType());
+            ps.setObject(parameterIndex, value);
         }
     }
 

--- a/coffee-jpa/src/test/java/hu/icellmobilsoft/coffee/jpa/sql/batch/BatchServiceTest.java
+++ b/coffee-jpa/src/test/java/hu/icellmobilsoft/coffee/jpa/sql/batch/BatchServiceTest.java
@@ -98,13 +98,21 @@ class BatchServiceTest {
 
     @Order(1)
     @ParameterizedTest(name = "[{index}] - type: [{0}] value: [{1}]")
-    @MethodSource({ "provideDateTypes", "provideTimeTypes", "provideTimestampTypes" })
-    void setPsObjectDateAndTimeAndTimestampWithoutTimezoneTest(SingleColumnType<?> type, Object value) throws SQLException {
+    @MethodSource({ "provideDateTypes" })
+    void setPsObjectDateWithoutTimezoneTest(SingleColumnType<?> type, Object value) throws SQLException {
+        batchService.setPsObject(preparedStatement, 0, type, value);
+        Mockito.verify(preparedStatement).setObject(0, value);
+    }
+
+    @Order(2)
+    @ParameterizedTest(name = "[{index}] - type: [{0}] value: [{1}]")
+    @MethodSource({ "provideTimeTypes", "provideTimestampTypes" })
+    void setPsObjectTimeAndTimestampWithoutTimezoneTest(SingleColumnType<?> type, Object value) throws SQLException {
         batchService.setPsObject(preparedStatement, 0, type, value);
         Mockito.verify(preparedStatement).setObject(0, value, type.sqlType());
     }
 
-    @Order(2)
+    @Order(3)
     @ParameterizedTest(name = "[{index}] - type: [{0}] value: [{1}]")
     @MethodSource("provideDateTypes")
     void setPsObjectDateWithTimezoneTest(SingleColumnType<?> type, Object value) throws SQLException {
@@ -113,10 +121,10 @@ class BatchServiceTest {
 
         batchService.setPsObject(preparedStatement, 0, type, value);
 
-        Mockito.verify(preparedStatement).setObject(0, value, Types.DATE);
+        Mockito.verify(preparedStatement).setObject(0, value);
     }
 
-    @Order(3)
+    @Order(4)
     @ParameterizedTest(name = "[{index}] - type: [{0}] value: [{1}] expectedValue: [{2}]")
     @MethodSource("provideTimeTypes")
     void setPsObjectTimeWithTimezoneTest(SingleColumnType<?> type, Object value, Object expectedValue) throws SQLException {
@@ -135,7 +143,7 @@ class BatchServiceTest {
         }
     }
 
-    @Order(4)
+    @Order(5)
     @ParameterizedTest(name = "[{index}] - type: [{0}] value: [{1}] expectedValue: [{2}]")
     @MethodSource("provideTimestampTypes")
     void setPsObjectTimestampWithTimezoneTest(SingleColumnType<?> type, Object value, Object expectedValue) throws SQLException {

--- a/docs/migration/migration1120to1130.adoc
+++ b/docs/migration/migration1120to1130.adoc
@@ -82,6 +82,9 @@ A változtatások nem eredményeznek átállási munkálatokat, visszafelé komp
 * A `BatchService` `java.sql.Types.BOOLEAN` mentés esetén, oracle jdbc driver használatával `java.sql.SQLException: Invalid column type` hibát eredményezett.
 A `null` értékű objektumok `prepared statement` beállítás esetén mentesítve lettek az SQL típusoktól és univerzálisan `java.sql.Types.NULL` kerül beállításra.
 A `java.sql.Types.BOOLEAN` típusok külön ágban kerülnek kezelésre, amelyben ha a beállítandó érték `java.lang.Boolean`, akkor a `prepared statement` erre biztosított `setBoolean(int parameterIndex, boolean x)` metódusa van használva, egyébként pedig a `setObject(int parameterIndex, Object x)`, amelyben a driver-re bízzuk, hogy kezelje le az adott értéket.
+* Továbbá a `BatchService` `java.sql.Types.BLOB` mentés esetén, oracle jdbc driver használatával szintén `java.sql.SQLException: Invalid column type` kivétel dobódott.
+Amennyiben a `BatchService.setSingleColumnPsObject()` metódusban egyetlen ágra sem illeszkedik a kapott `org.hibernate.type.SingleColumnType<?>` paraméter, 
+a default ágon a `setObject(int parameterIndex, Object x)` hívás típus átadás nélkül hívódik meg, hogy az Oracle driver maga detektálja a megfelelő típust.
 
 ==== Átállás
 


### PR DESCRIPTION
- A `BatchService.setSingleColumnPsObject()` metódusban a default ágon típus nélkül kerül meghívásra a `ps.setObject()˙.
- Migrációs dokumentáció frissítése.