### PR TITLE
Feature/708 commons io dependency upgrade

### DIFF
--- a/coffee-bom/coffee-bom-all/pom.xml
+++ b/coffee-bom/coffee-bom-all/pom.xml
@@ -17,23 +17,23 @@
         <version.google.code.gson>2.8.9</version.google.code.gson>
 
         <version.org.jboss.logging.jboss-logging>3.4.3.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
+        <version.org.apache.commons.commons-lang3>3.15.0</version.org.apache.commons.commons-lang3>
         <version.com.google.guava>32.1.1-jre</version.com.google.guava>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
-        <version.commons-codec>1.15</version.commons-codec>
+        <version.commons-codec>1.17.1</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
-        <version.commons-io>2.11.0</version.commons-io>
+        <version.commons-io>2.16.1</version.commons-io>
         <version.commons-email2-jakarta>2.0.0-M1</version.commons-email2-jakarta>
         <version.org.jboss.resteasy>6.2.1.Final</version.org.jboss.resteasy>
         <version.org.hibernate>6.6.1.Final</version.org.hibernate>
-        <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
-        <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
 
         <version.io.etcd.jetcd-core>0.7.5</version.io.etcd.jetcd-core>
         <version.io.grpc.version>1.51.0</version.io.grpc.version>
 
         <version.io.micrometer>1.9.13</version.io.micrometer>
-        <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>3.0.4</version.org.eclipse.yasson>
     </properties>
 
 

--- a/docs/en/migration/migration2100to2110.adoc
+++ b/docs/en/migration/migration2100to2110.adoc
@@ -12,6 +12,7 @@ coff:ee v2.10.0 -> v2.11.0 migration description, news, changes
 * commons.io version bump 2.11.0 -> 2.16.1
 * httpcomponents-httpclient version bump 4.5.13 -> 4.5.14 
 * httpcomponents-httpcore version bump 4.4.15 -> 4.4.16 
+* eclipse-yasson version bump 3.0.3 -> 3.0.4
 
 === coffee-tool
 * GZipUtil got some new method for lower memory usage and direct DTO/JSON compression

--- a/docs/hu/migration/migration2100to2110.adoc
+++ b/docs/hu/migration/migration2100to2110.adoc
@@ -12,6 +12,7 @@ coff:ee v2.10.0 -> v2.11.0 migrációs leírás, újdonságok, változások leí
 * commons.io version bump 2.11.0 -> 2.16.1
 * httpcomponents-httpclient version bump 4.5.13 -> 4.5.14 
 * httpcomponents-httpcore version bump 4.4.15 -> 4.4.16 
+* eclipse-yasson version bump 3.0.3 -> 3.0.4
 
 === coffee-tool
 * GZipUtil kapott néhány új metódust a kisebb memóriahasználatért, valamint DTO/JSON tömörítésre


### PR DESCRIPTION
* commons-lang3 version bump 3.12.0 -> 3.15.0 
* commons-codec version bump 1.15 -> 1.17.1
* commons.io version bump 2.11.0 -> 2.16.1
* httpcomponents-httpclient version bump 4.5.13 -> 4.5.14 
* httpcomponents-httpcore version bump 4.4.15 -> 4.4.16 