### PR TITLE
#779 use not aarch64 property

### DIFF
--- a/coffee-dto/coffee-dto-stub-gen/pom.xml
+++ b/coffee-dto/coffee-dto-stub-gen/pom.xml
@@ -139,7 +139,7 @@
             <id>protoc-java-gen-with-downloaded-artifact</id>
             <activation>
                 <os>
-                    <arch>x86_64</arch>
+                    <arch>!aarch64</arch>
                 </os>
             </activation>
             <build>


### PR DESCRIPTION
closes #779 

Külön release-notes-t nem írtam, mert ebben a verzióban romlott el korábban.